### PR TITLE
Tell Clojure test to use init() with default LOCALHOST backend.

### DIFF
--- a/src/test/clojure/testJS.clj
+++ b/src/test/clojure/testJS.clj
@@ -134,7 +134,7 @@
           ^Thread runner (Thread. (fn [] (Runner/run record interrupt BackendType/LOCALHOST)))
          ]
       (println (.source survey))
-      (Runner/init BackendType/LOCALHOST)
+      (Runner/init)
       (HTML/spitHTMLToFile (HTML/getHTMLString survey (LocalHTML.)) survey)
       (assert (not= (count (Slurpie/slurp (.getHtmlFileName record))) 0))
       (Server/startServe)


### PR DESCRIPTION
I believe this fixes the `make test` issue.  Tests run until they spit out:

```
org.openqa.selenium.firefox.NotConnectedException: Unable to connect to host 127.0.0.1 on port 7055 after 45000 ms.
```

I suspect that this error is because I don't have the Firefox testing setup that you have on your end.  When you get a chance, could you post some instructions for setting up the Firefox tests?  Alternately, you could just make them a separate target.  In any case, I should probably be running at least some of the tests before I send pull requests-- I should have done that before the last one I sent.
